### PR TITLE
Remove support for deprecated version 15.x

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -68,34 +68,6 @@ api = "0.5"
     version = "14.18.1"
 
   [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:nodejs:node.js:15.13.0:*:*:*:*:*:*:*"
-    deprecation_date = "2021-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-3-Clause-Clear", "CC0-1.0", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v15.13.0?checksum=96926e5b8f2f3ea805596448f01b16115882f3a594e2e999dc7349f80b3ec1f8&download_url=https://nodejs.org/dist/v15.13.0/node-v15.13.0.tar.gz"
-    sha256 = "1ddd140fa72ed2b66f666231da512f9e593d4ea99a0b80e011a72056f5eba9ef"
-    source = "https://nodejs.org/dist/v15.13.0/node-v15.13.0.tar.gz"
-    source_sha256 = "96926e5b8f2f3ea805596448f01b16115882f3a594e2e999dc7349f80b3ec1f8"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/node/node_v15.13.0_linux_x64_bionic_1ddd140f.tgz"
-    version = "15.13.0"
-
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:nodejs:node.js:15.14.0:*:*:*:*:*:*:*"
-    deprecation_date = "2021-06-01T00:00:00Z"
-    id = "node"
-    licenses = ["0BSD", "Apache-2.0", "Artistic-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-3-Clause-Clear", "CC0-1.0", "MIT", "MIT-0", "Unicode-TOU"]
-    name = "Node Engine"
-    purl = "pkg:generic/node@v15.14.0?checksum=f3a35c1b29b58846575085fdee7774d78b75ff4cf1e52572afce7f38685b159a&download_url=https://nodejs.org/dist/v15.14.0/node-v15.14.0.tar.gz"
-    sha256 = "e04f8e8c133af229f737d9059ef25e9b2a490dd0fdabb5367f00ef5c8cadf71e"
-    source = "https://nodejs.org/dist/v15.14.0/node-v15.14.0.tar.gz"
-    source_sha256 = "f3a35c1b29b58846575085fdee7774d78b75ff4cf1e52572afce7f38685b159a"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/node/node_v15.14.0_linux_x64_bionic_e04f8e8c.tgz"
-    version = "15.14.0"
-
-  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:nodejs:node.js:16.11.0:*:*:*:*:*:*:*"
     deprecation_date = "2024-04-30T00:00:00Z"
     id = "node"
@@ -130,11 +102,6 @@ api = "0.5"
 
   [[metadata.dependency-constraints]]
     constraint = "14.*"
-    id = "node"
-    patches = 2
-
-  [[metadata.dependency-constraints]]
-    constraint = "15.*"
     id = "node"
     patches = 2
 


### PR DESCRIPTION
Node 15.x reached End of Line on 2021-06-01.
(https://github.com/nodejs/Release)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
